### PR TITLE
Fix bug that allowed duplicate cluster names 

### DIFF
--- a/src/core/commands/commands.odin
+++ b/src/core/commands/commands.odin
@@ -92,14 +92,33 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 
 				id := data.OST_GENERATE_CLUSTER_ID()
 				success := data.OST_CREATE_CLUSTER_FROM_CL(collection_name, cluster_name, id)
-				if !success {
-					fmt.println("Failed to create cluster. Please check error messages.")
+				result := data.OST_CREATE_CLUSTER_FROM_CL(collection_name, cluster_name, id)
+				switch (result) 
+				{
+				case -1:
+					fmt.printfln(
+						"Cluster with name: %s%s%s already exists within collection %s%s%s. Failed to create cluster.",
+						misc.BOLD,
+						cluster_name,
+						misc.RESET,
+						misc.BOLD,
+						collection_name,
+						misc.RESET,
+					)
+					break
+				case 1, 2, 3:
+					error1 := errors.new_err(
+						.CANNOT_CREATE_CLUSTER,
+						errors.get_err_msg(.CANNOT_CREATE_CLUSTER),
+						#procedure,
+					)
+					errors.throw_custom_err(
+						error1,
+						"Failed to create cluster due to internal OstrichDB error.\n Check logs for more information.",
+					)
+					break
+
 				}
-			} else {
-				errors.throw_custom_err(
-					invalidCommandErr,
-					"Invalid NEW command structure. Correct Usage: NEW CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>",
-				)
 			}
 			break
 		case const.RECORD:

--- a/src/core/data/clusters.odin
+++ b/src/core/data/clusters.odin
@@ -16,8 +16,6 @@ import "core:strings"
 //=========================================================//
 
 
-
-
 main :: proc() {
 	OST_CREATE_CACHE_FILE()
 	os.make_directory(const.OST_COLLECTION_PATH)
@@ -423,7 +421,7 @@ OST_RENAME_CLUSTER :: proc(collection_name: string, old: string, new: string) ->
 
 
 //only used to create a cluster from the COMMAND LINE
-OST_CREATE_CLUSTER_FROM_CL :: proc(collectionName: string, clusterName: string, id: i64) -> bool {
+OST_CREATE_CLUSTER_FROM_CL :: proc(collectionName: string, clusterName: string, id: i64) -> int {
 
 	collection_path := fmt.tprintf(
 		"%s%s%s",
@@ -431,6 +429,12 @@ OST_CREATE_CLUSTER_FROM_CL :: proc(collectionName: string, clusterName: string, 
 		collectionName,
 		const.OST_FILE_EXTENSION,
 	)
+
+	clusterExist := OST_CHECK_IF_CLUSTER_EXISTS(collection_path, clusterName)
+	if clusterExist {
+		return -1
+	}
+
 	FIRST_HALF: []string = {"\n{\n\tcluster_name : %n"}
 	LAST_HALF: []string = {"\n\tcluster_id : %i\n\t\n},\n"} //defines the base structure of a cluster block in a .ost file
 	buf: [32]byte
@@ -445,7 +449,7 @@ OST_CREATE_CLUSTER_FROM_CL :: proc(collectionName: string, clusterName: string, 
 		)
 		errors.throw_err(error1)
 		logging.log_utils_error("Error opening collection file", "OST_CREATE_CLUSTER_BLOCK")
-		return false
+		return 1
 	}
 
 
@@ -478,7 +482,7 @@ OST_CREATE_CLUSTER_FROM_CL :: proc(collectionName: string, clusterName: string, 
 					"Error placing id into cluster template",
 					"OST_CREATE_CLUSTER_BLOCK",
 				)
-				return false
+				return 2
 			}
 			writeClusterID, writeSuccess := os.write(clusterFile, transmute([]u8)newClusterID)
 			if writeSuccess != 0 {
@@ -491,11 +495,11 @@ OST_CREATE_CLUSTER_FROM_CL :: proc(collectionName: string, clusterName: string, 
 					"Error writing cluster block to file",
 					"OST_CREATE_CLUSTER_BLOCK",
 				)
-				return false
+				return 3
 			}
 		}
 	}
-	return true
+	return 0
 }
 
 


### PR DESCRIPTION
This PR consists of the the following changes:

- Fix bug that allowed multiple cluster of the same name within a collection to be created

- Update  procedure `OST_CREATE_CLUSTER_FROM_CL `

- closes #26
