### PR TITLE
Add user session timer logic

### DIFF
--- a/src/core/const/constants.odin
+++ b/src/core/const/constants.odin
@@ -1,5 +1,5 @@
 package const
-
+import "core:time"
 //used in metadata.odin
 OST_FFVF :: "ost_file_format_version.tmp"
 OST_TMP_PATH :: "../bin/tmp/"
@@ -63,3 +63,10 @@ INT :: "INT"
 FLOAT :: "FLOAT"
 BOOL :: "BOOL"
 //might add more...doubtful though
+
+
+//3 days in nanoseconds
+MAX_SESSION_TIME: time.Duration : 259200000000000000
+
+//1 minute in nano seconds only used for testing
+// MAX_SESSION_TIME: time.Duration : 60000000000

--- a/src/core/engine/engine.odin
+++ b/src/core/engine/engine.odin
@@ -80,6 +80,8 @@ OST_ENGINE_COMMAND_LINE :: proc() {
 	fmt.println("Welcome to the OstrichDB Command Line")
 	utils.log_runtime_event("Entered command line", "")
 	for {
+
+
 		//Command line start
 		buf: [1024]byte
 		fmt.print(const.ost_carrot, "\t")
@@ -97,6 +99,16 @@ OST_ENGINE_COMMAND_LINE :: proc() {
 		// fmt.printfln("Command: %v", cmd) //debugging
 		commands.OST_EXECUTE_COMMAND(&cmd)
 
+		//Check to ensure that before the next command is executed, the max session time hasnt been met
+		sessionDuration := security.OST_GET_SESSION_DURATION()
+		maxDurationMet := security.OST_CHECK_SESSION_DURATION(sessionDuration)
+		switch (maxDurationMet) 
+		{
+		case false:
+			break
+		case true:
+			security.OST_HANDLE_MAX_SESSION_DURATION_MET()
+		}
 
 		switch (types.focus.flag) 
 		{

--- a/src/core/security/auth.odin
+++ b/src/core/security/auth.odin
@@ -134,6 +134,7 @@ OST_USER_LOGOUT :: proc(param: int) -> bool {
 		case 0:
 			USER_SIGNIN_STATUS = false
 			fmt.printfln("You have been logged out.")
+			OST_STOP_SESSION_TIMER()
 			OST_RUN_SIGNIN()
 			break
 		case 1:

--- a/src/core/security/sessions.odin
+++ b/src/core/security/sessions.odin
@@ -1,0 +1,50 @@
+package security
+
+import "../../utils"
+import "../const"
+import "core:fmt"
+import "core:strconv"
+import "core:strings"
+import "core:time"
+
+
+//=====================================<Session Timer Stuff>=====================================//
+stopWatch: time.Stopwatch
+
+OST_START_SESSION_TIMER :: proc() {
+	time.stopwatch_start(&stopWatch)
+}
+
+OST_STOP_SESSION_TIMER :: proc() {
+	time.stopwatch_stop(&stopWatch)
+}
+
+OST_GET_SESSION_DURATION :: proc() -> time.Duration {
+	sessionDuration := time.stopwatch_duration(stopWatch)
+	return sessionDuration
+}
+
+//simply checks if the session duration has met the maximum allowed session time yet
+OST_CHECK_SESSION_DURATION :: proc(sessionDuration: time.Duration) -> bool {
+
+	maxDurationMet := false
+	if sessionDuration > const.MAX_SESSION_TIME {
+		maxDurationMet = true
+	}
+	return maxDurationMet
+}
+
+
+OST_HANDLE_MAX_SESSION_DURATION_MET :: proc() {
+	fmt.printfln(
+		"Maximum session time of %s3 Days%s has been met. You will be automatically logged out. Please log back in.",
+		utils.BOLD,
+		utils.RESET,
+	)
+	//force logout
+	OST_USER_LOGOUT(0)
+	utils.log_runtime_event(
+		"Max Session Time Met",
+		" User has been forced logged out due to reaching maximum session time.",
+	)
+}


### PR DESCRIPTION
This pull request contains the follwing changes:

- Added a sessions.odin file

- Implemented basic OstrichDB user session timer

- Added Security logic when max session duration has been met

- closes #12