### PR TITLE
Fix FOCUS command not needing arguments

### DIFF
--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -299,10 +299,11 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 	//FOCUS and UNFOCUS: Enter at own peril.
 	case const.FOCUS:
 		utils.log_runtime_event("Used FOCUS command", "")
-		types.focus.flag = true
+
 		switch (cmd.t_token) 
 		{
 		case const.COLLECTION:
+			types.focus.flag = true
 			if len(cmd.o_token) > 0 {
 				collection := cmd.o_token[0]
 				storedT, storedO := OST_FOCUS(const.COLLECTION, collection)
@@ -314,6 +315,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.CLUSTER:
+			types.focus.flag = true
 			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token {
 				cluster := cmd.o_token[0]
 				collection := cmd.o_token[1]
@@ -322,6 +324,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			break
 		//todo: come back to this..havent done enough commands to test this in focus mode yet
 		case const.RECORD:
+			types.focus.flag = true
 			if len(cmd.o_token) >= 3 && const.WITHIN in cmd.m_token {
 				record := cmd.o_token[0]
 				cluster := cmd.o_token[1]
@@ -345,6 +348,11 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 				)
 				//storing the Target and Objec that the user wants to focus)
 			}
+			break
+		case:
+			fmt.printfln(
+				"Invalid FOCUS command structure. Correct Usage: FOCUS <collection_name> or FOCUS <cluster_name> WITHIN COLLECTION <collection_name>",
+			)
 			break
 		}
 

--- a/src/core/engine/data/metadata/metadata.odin
+++ b/src/core/engine/data/metadata/metadata.odin
@@ -224,7 +224,7 @@ OST_METADATA_ON_CREATE :: proc(fn: string) {
 
 
 OST_CREATE_FFVF :: proc() {
-	CURRENT_FFV := "Pre_Rel_v0.1.0_dev" //todo allow this to be directly read from the projetcs 'version' file and not hardcoded
+	CURRENT_FFV := "Pre_Rel_v0.2.0_dev" //todo allow this to be directly read from the projetcs 'version' file and not hardcoded
 	os.make_directory(const.OST_TMP_PATH)
 
 	FFVF := const.OST_FFVF

--- a/src/core/engine/engine.odin
+++ b/src/core/engine/engine.odin
@@ -149,7 +149,7 @@ OST_FOCUSED_COMMAND_LINE :: proc() {
 		}
 		input := strings.trim_right(string(buf[:n]), "\r\n")
 		cmd := OST_PARSE_COMMAND(input)
-		fmt.printfln("Command: %v", cmd) //debugging
+		// fmt.printfln("Command: %v", cmd) //debugging
 		EXECUTE_COMMANDS_WHILE_FOCUSED(&cmd, types.focus.t_, types.focus.o_)
 		//Command line end
 	}

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-Pre_Rel_v0.1.0_dev
+Pre_Rel_v0.2.0_dev


### PR DESCRIPTION
This pull request contains the following changes:

- Now prevents entering FOCUS mode when using `FOCUS` command without arguments

- Updated OstrichDB version file to `Pre_Rel_v.0.2.0_dev`

- Updated file format version to  `Pre_Rel_v.0.2.0_dev`


- closes #47