### PR TITLE
Update file size and last modified metadata after command execution

### DIFF
--- a/src/core/engine/data/backup.odin
+++ b/src/core/engine/data/backup.odin
@@ -19,7 +19,6 @@ OST_CREATE_BACKUP_COLLECTION :: proc(dest: string, src: string) -> bool {
 	//retirve the data from the src collection file
 	srcNameAndPath := strings.concatenate([]string{const.OST_COLLECTION_PATH, src})
 	srcFullPath := strings.concatenate([]string{srcNameAndPath, const.OST_FILE_EXTENSION})
-	fmt.println("srcFullPath: ", srcFullPath)
 	f, readSuccess := os.read_entire_file(srcFullPath)
 	if !readSuccess {
 		error1 := new_err(.CANNOT_READ_FILE, get_err_msg(.CANNOT_READ_FILE), #procedure)
@@ -65,7 +64,6 @@ OST_CHOOSE_BACKUP_NAME :: proc() -> string {
 		utils.throw_err(error1)
 	}
 	str := strings.trim_right(string(buf[:n]), "\r\n")
-	fmt.printfln("You chose: %s", str)
 
 	return str
 }


### PR DESCRIPTION
This pull request contains the following changes:

- Updated the OstrichDB command line to now update collection(.ost) file metadata after any command that changes the data within the file is executed. Commands such as FETCH & FOCUS have no impact thus aren't affected

- Remove some trash

- closes #38