### PR TITLE
fix: embed the version file into the binary

### DIFF
--- a/src/utils/misc.odin
+++ b/src/utils/misc.odin
@@ -36,14 +36,7 @@ RESET :: "\033[0m"
 
 
 get_ost_version :: proc() -> []u8 {
-	version_file, openSuccess := os.open("../version")
-	if openSuccess != 0 {
-		log_err("Could not open version file", "get_ost_version")
-	}
-	data, e := os.read_entire_file(version_file)
-	if e == false {
-	}
-	os.close(version_file)
+	data := #load("../../version")
 	return data
 }
 


### PR DESCRIPTION
Initially, the version file is loaded dynamically each time the application is run. This means, the version file will have to be shipped with the binary when deployed. This fix embeds the content of the version file into the binary at compile time.