### PR TITLE
fix issue when comparing errors with boolean values

### DIFF
--- a/src/core/engine/data/collections.odin
+++ b/src/core/engine/data/collections.odin
@@ -263,7 +263,7 @@ OST_RENAME_COLLECTION :: proc(old: string, new: string) -> bool {
 	newNameExt := fmt.tprintf("%s%s", const.OST_COLLECTION_PATH, newName)
 	renamed := os.rename(oldPathAndExt, newNameExt)
 
-	if renamed != true {
+	if renamed != os.ERROR_NONE {
 		utils.log_err("Error renaming .ost file", #procedure)
 		return false
 	}

--- a/src/core/engine/data/quarantine.odin
+++ b/src/core/engine/data/quarantine.odin
@@ -36,7 +36,7 @@ OST_QURANTINE_COLLECTION :: proc(fn: string) -> int {
 	quarantine_path := fmt.tprintf("%s/%s", const.OST_QUARANTINE_PATH, quarantineFilename)
 	// Move the file to quarantine
 	err := os.rename(collectionFile, quarantine_path)
-	if err != false {
+	if err != os.ERROR_NONE {
 		return -1
 	}
 	OST_APPEND_QUARANTINE_LINE(quarantine_path)


### PR DESCRIPTION
There was an issue in 2 files where an error value was being compared with a boolean, which prevented the program from compiling. I've updated it to compare instead with the ERROR enum value. It now compiles correctly (on Linux).