### PR TITLE
Implement dot notation for commands

### DIFF
--- a/src/core/const/constants.odin
+++ b/src/core/const/constants.odin
@@ -79,6 +79,9 @@ ATOM :: "ATOM"
 YES :: "YES"
 NO :: "NO"
 
+//FOR DOT NOTATION
+DOT :: "."
+
 //MISC CONSTANTS
 ost_carrot :: "OST>>>"
 VALID_RECORD_TYPES: []string : {STRING, INTEGER, FLOAT, BOOLEAN, STR, INT, FLT, BOOL}

--- a/src/core/engine/auth.odin
+++ b/src/core/engine/auth.odin
@@ -55,8 +55,6 @@ OST_RUN_SIGNIN :: proc() -> bool {
 		types.user.role.Value = "guest"
 	}
 
-	fmt.printfln("Username that was found: %s", userNameFound)
-
 	if (userNameFound != userName) {
 		error2 := utils.new_err(
 			.ENTERED_USERNAME_NOT_FOUND,

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -31,7 +31,9 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 		utils.get_err_msg(.INCOMPLETE_COMMAND),
 		#procedure,
 	)
-
+	if cmd.isUsingDotNotation == true {
+		fmt.printfln("Using dot notation is not supported in this version of OstrichDB.")
+	}
 	invalidCommandErr := utils.new_err(
 		.INVALID_COMMAND,
 		utils.get_err_msg(.INVALID_COMMAND),
@@ -111,7 +113,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			fmt.printfln("Command number %d not found", commandIndex + 1) // add one to make it reflect what the user sees
 			break
 		}
-
+		// parses the command that has been stored in the most recent command history index. Crucial for the HISTORY command
 		cmd := OST_PARSE_COMMAND(const.CommandHistory[commandIndex])
 		OST_EXECUTE_COMMAND(&cmd)
 		break

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -493,11 +493,11 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token && const.TO in cmd.m_token ||
 			   cmd.isUsingDotNotation == true {
 				// if cmd.isUsingDotNotation == true {}
-				old_name := cmd.o_token[0]
-				collection_name := cmd.o_token[1]
+				old_name := cmd.o_token[1]
+				collection_name := cmd.o_token[0]
 				new_name := cmd.m_token[const.TO]
-				fmt.printfln("Old_name: %s", old_name)
 				fmt.printfln("Collection_name: %s", collection_name)
+				fmt.printfln("Old_name: %s", old_name)
 				fmt.printfln("New_name: %s", new_name)
 
 				checks := data.OST_HANDLE_INTGRITY_CHECK_RESULT(collection_name)

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -245,10 +245,18 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.CLUSTER:
+			cluster_name: string
+			collection_name: string
 			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
 			   cmd.isUsingDotNotation == true {
-				cluster_name := cmd.o_token[0]
-				collection_name := cmd.o_token[1]
+				if cmd.isUsingDotNotation == true {
+					collection_name = cmd.o_token[0]
+					cluster_name = cmd.o_token[1]
+					fmt.println("Using dot notation")
+				} else {
+					cluster_name = cmd.o_token[0]
+					collection_name = cmd.o_token[1]
+				}
 				fmt.printf(
 					"Creating cluster: %s%s%s within collection: %s%s%s\n",
 					utils.BOLD_UNDERLINE,

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -711,6 +711,53 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.RECORD:
+			collection_name: string
+			cluster_name: string
+			record_name: string
+
+			if len(cmd.o_token) == 3 && const.WITHIN in cmd.m_token ||
+			   cmd.isUsingDotNotation == true {
+				collection_name := cmd.o_token[0]
+				cluster_name := cmd.o_token[1]
+				record_name := cmd.o_token[2]
+
+				clusterID := data.OST_GET_CLUSTER_ID(collection_name, cluster_name)
+				checks := data.OST_HANDLE_INTGRITY_CHECK_RESULT(collection_name)
+				switch (checks) 
+				{
+				case -1:
+					return -1
+				}
+
+				if data.OST_ERASE_RECORD(collection_name, cluster_name, record_name) == true {
+					fmt.printfln(
+						"Record: %s%s%s successfully erased from cluster: %s%s%s within collection: %s%s%s",
+						utils.BOLD_UNDERLINE,
+						record_name,
+						utils.RESET,
+						utils.BOLD_UNDERLINE,
+						cluster_name,
+						utils.RESET,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					data.OST_REMOVE_ID_FROM_CACHE(clusterID)
+				} else {
+					fmt.printfln(
+						"Failed to erase record: %s%s%s from cluster: %s%s%s within collection: %s%s%s",
+						utils.BOLD_UNDERLINE,
+						record_name,
+						utils.RESET,
+						utils.BOLD_UNDERLINE,
+						cluster_name,
+						utils.RESET,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+				}
+			}
 			break
 		case:
 			fmt.printfln(

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -249,11 +249,11 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			collection_name: string
 			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
 			   cmd.isUsingDotNotation == true {
+				//using dot notation
 				if cmd.isUsingDotNotation == true {
 					collection_name = cmd.o_token[0]
 					cluster_name = cmd.o_token[1]
-					fmt.println("Using dot notation")
-				} else {
+				} else { 	//using within
 					cluster_name = cmd.o_token[0]
 					collection_name = cmd.o_token[1]
 				}
@@ -485,15 +485,28 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.CLUSTER:
-			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token && const.TO in cmd.m_token {
+			// old_name: string
+			// new_name: string
+			cluster_name: string
+			collection_name: string
+
+			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token && const.TO in cmd.m_token ||
+			   cmd.isUsingDotNotation == true {
+				// if cmd.isUsingDotNotation == true {}
 				old_name := cmd.o_token[0]
 				collection_name := cmd.o_token[1]
 				new_name := cmd.m_token[const.TO]
+				fmt.printfln("Old_name: %s", old_name)
+				fmt.printfln("Collection_name: %s", collection_name)
+				fmt.printfln("New_name: %s", new_name)
 
 				checks := data.OST_HANDLE_INTGRITY_CHECK_RESULT(collection_name)
 				switch (checks) 
 				{
 				case -1:
+					fmt.printfln(
+						"Failed to rename cluster %s%s%s to %s%s%s in collection %s%s%s\n",
+					)
 					return -1
 				}
 

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -485,8 +485,6 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.CLUSTER:
-			// old_name: string
-			// new_name: string
 			cluster_name: string
 			collection_name: string
 
@@ -620,9 +618,13 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.CLUSTER:
-			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token {
-				collection_name := cmd.o_token[1]
-				cluster := cmd.o_token[0]
+			collection_name: string
+			cluster_name: string
+
+			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
+			   cmd.isUsingDotNotation == true {
+				collection_name := cmd.o_token[0]
+				cluster := cmd.o_token[1]
 				clusterID := data.OST_GET_CLUSTER_ID(collection_name, cluster)
 				checks := data.OST_HANDLE_INTGRITY_CHECK_RESULT(collection_name)
 				switch (checks) 
@@ -697,9 +699,12 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.CLUSTER:
-			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token {
-				collection := cmd.o_token[1]
-				cluster := cmd.o_token[0]
+			collection_name: string
+			cluster_name: string
+			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
+			   cmd.isUsingDotNotation == true {
+				collection := cmd.o_token[0]
+				cluster := cmd.o_token[1]
 				checks := data.OST_HANDLE_INTGRITY_CHECK_RESULT(collection)
 				switch (checks) 
 				{

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -31,9 +31,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 		utils.get_err_msg(.INCOMPLETE_COMMAND),
 		#procedure,
 	)
-	if cmd.isUsingDotNotation == true {
-		fmt.printfln("Using dot notation is not supported in this version of OstrichDB.")
-	}
+
 	invalidCommandErr := utils.new_err(
 		.INVALID_COMMAND,
 		utils.get_err_msg(.INVALID_COMMAND),
@@ -247,7 +245,8 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.CLUSTER:
-			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token {
+			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
+			   cmd.isUsingDotNotation == true {
 				cluster_name := cmd.o_token[0]
 				collection_name := cmd.o_token[1]
 				fmt.printf(

--- a/src/core/engine/data/clusters.odin
+++ b/src/core/engine/data/clusters.odin
@@ -147,7 +147,7 @@ OST_REMOVE_ID_FROM_CACHE :: proc(id: i64) -> bool {
 	deleted := false
 	buf: [32]byte
 	idStr := strconv.append_int(buf[:], id, 10)
-	fmt.printfln("ID to delete: %s", idStr)
+
 
 	data, readSuccess := os.read_entire_file(const.OST_CLUSTER_CACHE_PATH)
 	if !readSuccess {

--- a/src/core/engine/data/clusters.odin
+++ b/src/core/engine/data/clusters.odin
@@ -422,6 +422,9 @@ OST_CHECK_IF_CLUSTER_EXISTS :: proc(fn: string, cn: string) -> bool {
 }
 
 OST_RENAME_CLUSTER :: proc(collection_name: string, old: string, new: string) -> bool {
+	fmt.printfln("getting collection name:%s")
+	fmt.printfln("getting old cluster name:%s")
+	fmt.printfln("getting new cluster name:%s")
 	collection_path := fmt.tprintf(
 		"%s%s%s",
 		const.OST_COLLECTION_PATH,
@@ -461,15 +464,16 @@ OST_RENAME_CLUSTER :: proc(collection_name: string, old: string, new: string) ->
 
 	clusterFound := false
 	for cluster in clusters {
-		if strings.contains(cluster, fmt.tprintf("cluster_name : %s", old)) {
+		if strings.contains(cluster, fmt.tprintf("cluster_name :identifier: %s", old)) {
 			// if a cluster with the old name is found, replace the name with the new name
 			clusterFound = true
 			newCluster, e := strings.replace(
 				cluster,
-				fmt.tprintf("cluster_name : %s", old),
-				fmt.tprintf("cluster_name : %s", new),
+				fmt.tprintf("cluster_name :identifier: %s", old),
+				fmt.tprintf("cluster_name :identifier: %s", new),
 				1,
 			)
+			fmt.printfln("newCLuster: %s", newCluster)
 			//append the new data to the new content variable
 			append(&newContent, ..transmute([]u8)newCluster)
 			// append the closing brace
@@ -477,7 +481,7 @@ OST_RENAME_CLUSTER :: proc(collection_name: string, old: string, new: string) ->
 		} else if len(strings.trim_space(cluster)) > 0 {
 			// For other clusters, just add them back unchanged and add the closing brace
 			append(&newContent, ..transmute([]u8)cluster)
-			append(&newContent, '}')
+			// append(&newContent, '}')
 		}
 	}
 

--- a/src/core/engine/data/clusters.odin
+++ b/src/core/engine/data/clusters.odin
@@ -473,7 +473,6 @@ OST_RENAME_CLUSTER :: proc(collection_name: string, old: string, new: string) ->
 				fmt.tprintf("cluster_name :identifier: %s", new),
 				1,
 			)
-			fmt.printfln("newCLuster: %s", newCluster)
 			//append the new data to the new content variable
 			append(&newContent, ..transmute([]u8)newCluster)
 			// append the closing brace

--- a/src/core/engine/engine.odin
+++ b/src/core/engine/engine.odin
@@ -112,7 +112,7 @@ OST_ENGINE_COMMAND_LINE :: proc() -> int {
 		append(&const.CommandHistory, strings.clone(input))
 
 		cmd := OST_PARSE_COMMAND(input)
-		fmt.printfln("Command: %v", cmd) //debugging
+		// fmt.printfln("Command: %v", cmd) //debugging
 		result := OST_EXECUTE_COMMAND(&cmd)
 		switch (result) 
 		{

--- a/src/core/engine/engine.odin
+++ b/src/core/engine/engine.odin
@@ -112,7 +112,7 @@ OST_ENGINE_COMMAND_LINE :: proc() -> int {
 		append(&const.CommandHistory, strings.clone(input))
 
 		cmd := OST_PARSE_COMMAND(input)
-		// fmt.printfln("Command: %v", cmd) //debugging
+		fmt.printfln("Command: %v", cmd) //debugging
 		result := OST_EXECUTE_COMMAND(&cmd)
 		switch (result) 
 		{

--- a/src/core/engine/parser.odin
+++ b/src/core/engine/parser.odin
@@ -56,7 +56,6 @@ OST_PARSE_COMMAND :: proc(input: string) -> types.Command {
 			// Expecting object or modifier
 			if OST_IS_VALID_MODIFIER(token) {
 				currentModifier = token
-				fmt.println("current modifier: ", currentModifier)
 				state = 2
 			} else {
 				if strings.contains(token, ".") {

--- a/src/core/engine/parser.odin
+++ b/src/core/engine/parser.odin
@@ -27,137 +27,125 @@ OST_IS_VALID_MODIFIER :: proc(token: string) -> bool {
 OST_PARSE_COMMAND :: proc(input: string) -> types.Command {
 	capitalInput := strings.to_upper(input)
 	tokens := strings.split(strings.trim_space(capitalInput), " ")
-	sepByDot: []string
+	fmt.println("tokens: ", tokens)
 
 	//dot notation will allow for accessing context like this: <action> <target> child.parent.grandparent or <action> <target> child.parent
-	child: string
-	parent: string
 	grandparent: string
-	for c := 1; c < len(tokens); c += 1 {
-		sepByDot = strings.split(strings.trim_space(tokens[c]), ".")
-		if len(sepByDot) == 3 {
-			child = sepByDot[2]
-			parent = sepByDot[1]
-			grandparent = sepByDot[0]
-		} else if len(sepByDot) == 2 {
-			child = sepByDot[1]
-			parent = sepByDot[0]
-		} else {
-			fmt.println("There can only be 1, 2, or 3 parts to a dot notation command")
-		}
+	parent: string
+	child: string
+	objTokensSepByDot: []string
+	cmd: types.Command
+
+	if len(tokens) == 0 {
+		return cmd
 	}
 
-	//debugging
-	fmt.println("grandparent from parser: ", grandparent)
-	fmt.println("parent from parser: ", parent)
-	fmt.println("child from parser: ", child)
-	//debugging
-	fmt.println("length of sep by dot: ", len(sepByDot))
-	fmt.println("sep by dot: ", sepByDot)
-	cmd := types.Command{}
-	//allowing this to evaluate if its greater >= 1 is super hacky
-	//and I dont think it should be this way, but fuck it I guess - Marshall Burns aka SchoolyB
-	switch (len(sepByDot) >= 1) {
+	//Firstly checking if appropriate token contains a dot.
+	//if so then recognize that we are using dot notation
+	for i := 0; i < len(tokens); i += 1 {
+		switch strings.contains(tokens[i], ".") {
+		//USING DOT NOTATION // USING DOT NOTATION // USING DOT NOTATION
+		case true:
+			//dont fucking ask me why I did this or why it works - Marshall Burns aka SchoolyB
+			if !strings.contains(tokens[0], ".") {
+				objTokensSepByDot = strings.split(strings.trim_space(tokens[i]), ".")
+				fmt.println("SeperatedByDot: ", objTokensSepByDot)
+				fmt.println("len(objTokensSepByDot): ", len(objTokensSepByDot))
 
-	//IF THE COMMAND IS USING DOT NOTATION example: new cluster foo.bar
-	case true:
-		cmd = types.Command {
-			o_token            = make([dynamic]string),
-			m_token            = make(map[string]string),
-			s_token            = make(map[string]string),
-			isUsingDotNotation = true,
-		}
-		if len(tokens) == 0 {
-			return cmd
-		}
-		currentModifier := ""
-		state := 0
-		cmd.a_token = strings.to_upper(tokens[0]) //i dont think i need to do this anymore
-		for i := 1; i < len(tokens); i += 1 {
-			token := strings.to_upper(tokens[i])
-			// Expecting target
-			cmd.t_token = tokens[i]
-			//append the grandparent, parent, and child to the o_token slice in that order
-			if grandparent != "" {
-				append(&cmd.o_token, grandparent)
-				fmt.println("grandparent that was appended: ", grandparent)
-			}
-			fmt.println("token: ", token)
-			// append(&cmd.o_token, parent)
-			// append(&cmd.o_token, child)
-			append(&cmd.o_token, parent)
-			append(&cmd.o_token, child)
+				switch (len(objTokensSepByDot)) 
+				{
+				case 1:
+					fmt.println("ERROR, something went wrong when trying to use dot notation...")
+				case 2:
+					parent = objTokensSepByDot[0]
+					child = objTokensSepByDot[1]
+					fmt.println("Getting parent: ", parent)
+					fmt.println("Getting child: ", child)
 
-			fmt.printfln("parent that was appended: %s", parent)
-			fmt.printfln("child that was appended: %s", child)
+				case 3:
+					grandparent = objTokensSepByDot[0]
+					parent = objTokensSepByDot[1]
+					child = objTokensSepByDot[2]
 
-
-			state = 1
-			switch state {
-			case 0:
-				// Expecting target
-				cmd.t_token = token
-				state = 1
-			case 1:
-				// Expecting object or modifier
-				fmt.println("token: ", token)
-				if OST_IS_VALID_MODIFIER(token) {
-					currentModifier = token
-					state = 2
-				} else {
-					append(&cmd.o_token, tokens[i]) // Preserve original case for objects
-					fmt.println("appended to o_token: ", tokens[i])
-					// state = 2
 				}
-			case 2:
-				// Expecting object after modifier
-				cmd.m_token[currentModifier] = tokens[i] // Preserve original case for modifier values
-				state = 1
 			}
-			return cmd
-		}
 
+			cmd = types.Command {
+				o_token            = make([dynamic]string),
+				m_token            = make(map[string]string),
+				s_token            = make(map[string]string),
+				isUsingDotNotation = true,
+			}
 
-	//IF THIS IS A NORMAL COMMAND example: new cluster foo within collecion bar
-	case false:
-		cmd = types.Command {
-			o_token            = make([dynamic]string),
-			m_token            = make(map[string]string),
-			s_token            = make(map[string]string),
-			isUsingDotNotation = false,
-		}
-		if len(tokens) == 0 {
-			return cmd
-		}
+			currentModifier := "" //stores the current modifier such as TO or WITHIN
+			state := 0 //state machine exclusivley used for modifier token shit
 
-		cmd.a_token = strings.to_upper(tokens[0])
+			cmd.a_token = tokens[0] //setting the action token
+			//iterate over remaing ATOM tokens and set/append them to the cmd
+			for j := 1; j < len(tokens); j += 1 {
+				token := tokens[j]
+				switch (state) {
+				case 0:
+					cmd.t_token = token
+					fmt.println("token: ", token)
+					state = 1
+				case 1:
+					//checking if the current token is a modifier; if it is add it to the modifer map
+					if OST_IS_VALID_MODIFIER(token) {
+						currentModifier = token
+						fmt.println("current modifier: ", currentModifier)
+						state = 2
+					} else {
+						for k := 0; k < len(objTokensSepByDot); k += 1 {
+							append(&cmd.o_token, objTokensSepByDot[k])
+						}
+					}
+				case 2:
+					for m := 0; m < len(objTokensSepByDot); m += 1 {
+						cmd.m_token[currentModifier] = token // Preserve original case for modifier values
+						state = 1
 
-		state := 0
-		current_modifier := ""
-
-		for i := 1; i < len(tokens); i += 1 {
-			token := strings.to_upper(tokens[i])
-
-			switch state {
-			case 0:
-				// Expecting target
-				cmd.t_token = token
-				state = 1
-			case 1:
-				// Expecting object or modifier
-				if OST_IS_VALID_MODIFIER(token) {
-					current_modifier = token
-					state = 2
-				} else {
-					append(&cmd.o_token, tokens[i]) // Preserve original case for objects
+					}
 				}
-			case 2:
-				// Expecting object after modifier
-				cmd.m_token[current_modifier] = tokens[i] // Preserve original case for modifier values
-				state = 1
 			}
+		//NOT USING DOT NOTATION // NOT USING DOT NOTATION // NOT USING DOT NOTATION
+		case false:
+			cmd = types.Command {
+				o_token            = make([dynamic]string),
+				m_token            = make(map[string]string),
+				s_token            = make(map[string]string),
+				isUsingDotNotation = false,
+			}
+
+			cmd.a_token = tokens[0]
+
+			state := 0
+			current_modifier := ""
+
+			for i := 1; i < len(tokens); i += 1 {
+				token := strings.to_upper(tokens[i])
+
+				switch state {
+				case 0:
+					// Expecting target
+					cmd.t_token = token
+					state = 1
+				case 1:
+					// Expecting object or modifier
+					if OST_IS_VALID_MODIFIER(token) {
+						current_modifier = token
+						state = 2
+					} else {
+						append(&cmd.o_token, tokens[i]) // Preserve original case for objects
+					}
+				case 2:
+					// Expecting object after modifier
+					cmd.m_token[current_modifier] = tokens[i] // Preserve original case for modifier values
+					state = 1
+				}
+			}
+			return cmd
 		}
-		return cmd
 	}
 	return cmd
 }

--- a/src/core/engine/parser.odin
+++ b/src/core/engine/parser.odin
@@ -13,6 +13,7 @@ import "core:strings"
 //=========================================================//
 
 OST_IS_VALID_MODIFIER :: proc(token: string) -> bool {
+	fmt.println("Token recieved while checking if is valid modifer: ", token)
 	using const
 	validModifiers := []string{AND, WITHIN, IN, OF_TYPE, TYPE, ALL_OF, TO}
 	for modifier in validModifiers {
@@ -27,43 +28,110 @@ OST_IS_VALID_MODIFIER :: proc(token: string) -> bool {
 OST_PARSE_COMMAND :: proc(input: string) -> types.Command {
 	capitalInput := strings.to_upper(input)
 	tokens := strings.split(strings.trim_space(capitalInput), " ")
-	cmd := types.Command {
-		o_token = make([dynamic]string),
-		m_token = make(map[string]string),
-		s_token = make(map[string]string),
-	}
+	sepByDot := strings.split(strings.trim_space(capitalInput), ".")
+	cmd := types.Command{}
+	switch (len(sepByDot) > 1) {
+	//IF THE COMMAND US USING DOT NOTATION example: new cluster foo.bar
+	case true:
+		cmd = types.Command {
+			o_token            = make([dynamic]string),
+			m_token            = make(map[string]string),
+			s_token            = make(map[string]string),
+			isUsingDotNotation = true,
+		}
+		fmt.println("Tokens: ", tokens)
+		fmt.println("SepByDot: ", sepByDot)
+		if len(tokens) == 0 {
+			return cmd
+		}
+		cmd.a_token = strings.to_upper(tokens[0]) //i dont think i need to do this anymore
 
-	if len(tokens) == 0 {
+		state := 0
+		current_modifier := ""
+
+		for i := 1; i < len(tokens); i += 1 {
+			token := strings.to_upper(tokens[i])
+			switch state {
+			case 0:
+				// Expecting target
+				cmd.t_token = tokens[i]
+				state = 1
+			case 1:
+				// Expecting object or modifier
+				if OST_IS_VALID_MODIFIER(tokens[i]) {
+					current_modifier = token
+					fmt.println("Current Modifier: ", current_modifier)
+					state = 2
+				} else {
+					dotSplit := strings.split(tokens[i], ".")
+					switch (len(dotSplit)) 
+					{
+					case 2:
+						fmt.println("Dot Split: ", dotSplit)
+						fmt.println("Dot Split Length: ", len(dotSplit))
+						for j := 0; j < len(dotSplit); j += 1 {
+							append(&cmd.o_token, dotSplit[j]) // Preserve original case for objects
+						}
+					case 3:
+						fmt.println("Dot Split: ", dotSplit)
+						fmt.println("Dot Split Length: ", len(dotSplit))
+						for j := 0; j < len(dotSplit); j += 1 {
+							append(&cmd.o_token, dotSplit[j]) // Preserve original case for objects
+						}
+					case:
+						fmt.println("There can only be 2 or 3 parts to a dot notation command")
+					}
+
+
+				}
+			case 2:
+				// Expecting object after modifier
+				cmd.m_token[current_modifier] = sepByDot[i] // Preserve original case for modifier values
+				state = 1
+			}
+			// return cmd
+		}
+
+	//IF THIS IS A NORMAL COMMAND example: new cluster foo within collecion bar
+	case false:
+		cmd = types.Command {
+			o_token            = make([dynamic]string),
+			m_token            = make(map[string]string),
+			s_token            = make(map[string]string),
+			isUsingDotNotation = false,
+		}
+		if len(tokens) == 0 {
+			return cmd
+		}
+
+		cmd.a_token = strings.to_upper(tokens[0])
+
+		state := 0
+		current_modifier := ""
+
+		for i := 1; i < len(tokens); i += 1 {
+			token := strings.to_upper(tokens[i])
+
+			switch state {
+			case 0:
+				// Expecting target
+				cmd.t_token = token
+				state = 1
+			case 1:
+				// Expecting object or modifier
+				if OST_IS_VALID_MODIFIER(token) {
+					current_modifier = token
+					state = 2
+				} else {
+					append(&cmd.o_token, tokens[i]) // Preserve original case for objects
+				}
+			case 2:
+				// Expecting object after modifier
+				cmd.m_token[current_modifier] = tokens[i] // Preserve original case for modifier values
+				state = 1
+			}
+		}
 		return cmd
 	}
-
-	cmd.a_token = strings.to_upper(tokens[0])
-
-	state := 0
-	current_modifier := ""
-
-	for i := 1; i < len(tokens); i += 1 {
-		token := strings.to_upper(tokens[i])
-
-		switch state {
-		case 0:
-			// Expecting target
-			cmd.t_token = token
-			state = 1
-		case 1:
-			// Expecting object or modifier
-			if OST_IS_VALID_MODIFIER(token) {
-				current_modifier = token
-				state = 2
-			} else {
-				append(&cmd.o_token, tokens[i]) // Preserve original case for objects
-			}
-		case 2:
-			// Expecting object after modifier
-			cmd.m_token[current_modifier] = tokens[i] // Preserve original case for modifier values
-			state = 1
-		}
-	}
-
 	return cmd
 }

--- a/src/core/engine/parser.odin
+++ b/src/core/engine/parser.odin
@@ -36,18 +36,23 @@ OST_PARSE_COMMAND :: proc(input: string) -> types.Command {
 	for c := 1; c < len(tokens); c += 1 {
 		sepByDot = strings.split(strings.trim_space(tokens[c]), ".")
 		if len(sepByDot) == 3 {
-			child = sepByDot[0]
+			child = sepByDot[2]
 			parent = sepByDot[1]
-			grandparent = sepByDot[2]
+			grandparent = sepByDot[0]
 		} else if len(sepByDot) == 2 {
-			child = sepByDot[0]
-			parent = sepByDot[1]
-		} else if len(sepByDot) == 1 {
-			child = sepByDot[0]
+			child = sepByDot[1]
+			parent = sepByDot[0]
 		} else {
 			fmt.println("There can only be 1, 2, or 3 parts to a dot notation command")
 		}
 	}
+
+	//debugging
+	fmt.println("grandparent from parser: ", grandparent)
+	fmt.println("parent from parser: ", parent)
+	fmt.println("child from parser: ", child)
+	//debugging
+
 	cmd := types.Command{}
 	switch (len(sepByDot) > 1) {
 
@@ -67,11 +72,14 @@ OST_PARSE_COMMAND :: proc(input: string) -> types.Command {
 			token := strings.to_upper(tokens[i])
 			// Expecting target
 			cmd.t_token = tokens[i]
-			append(&cmd.o_token, child)
-			append(&cmd.o_token, parent)
+			//append the grandparent, parent, and child to the o_token slice in that order
 			if grandparent != "" {
 				append(&cmd.o_token, grandparent)
 			}
+			append(&cmd.o_token, parent)
+			append(&cmd.o_token, child)
+
+			fmt.println("cmd.o_token from parser: ", cmd.o_token)
 			return cmd
 		}
 

--- a/src/core/engine/parser.odin
+++ b/src/core/engine/parser.odin
@@ -27,125 +27,54 @@ OST_IS_VALID_MODIFIER :: proc(token: string) -> bool {
 OST_PARSE_COMMAND :: proc(input: string) -> types.Command {
 	capitalInput := strings.to_upper(input)
 	tokens := strings.split(strings.trim_space(capitalInput), " ")
-	fmt.println("tokens: ", tokens)
-
 	//dot notation will allow for accessing context like this: <action> <target> child.parent.grandparent or <action> <target> child.parent
-	grandparent: string
-	parent: string
-	child: string
-	objTokensSepByDot: []string
-	cmd: types.Command
+	cmd := types.Command {
+		o_token            = make([dynamic]string),
+		m_token            = make(map[string]string),
+		s_token            = make(map[string]string),
+		isUsingDotNotation = false,
+	}
 
 	if len(tokens) == 0 {
 		return cmd
 	}
 
-	//Firstly checking if appropriate token contains a dot.
-	//if so then recognize that we are using dot notation
-	for i := 0; i < len(tokens); i += 1 {
-		switch strings.contains(tokens[i], ".") {
-		//USING DOT NOTATION // USING DOT NOTATION // USING DOT NOTATION
-		case true:
-			//dont fucking ask me why I did this or why it works - Marshall Burns aka SchoolyB
-			if !strings.contains(tokens[0], ".") {
-				objTokensSepByDot = strings.split(strings.trim_space(tokens[i]), ".")
-				fmt.println("SeperatedByDot: ", objTokensSepByDot)
-				fmt.println("len(objTokensSepByDot): ", len(objTokensSepByDot))
+	cmd.a_token = tokens[0] //setting the action token
+	state := 0 //state machine exclusively used for modifier token shit
+	currentModifier := "" //stores the current modifier such as TO or WITHIN
 
-				switch (len(objTokensSepByDot)) 
-				{
-				case 1:
-					fmt.println("ERROR, something went wrong when trying to use dot notation...")
-				case 2:
-					parent = objTokensSepByDot[0]
-					child = objTokensSepByDot[1]
-					fmt.println("Getting parent: ", parent)
-					fmt.println("Getting child: ", child)
+	//iterate over remaining ATOM tokens and set/append them to the cmd
+	for i := 1; i < len(tokens); i += 1 {
+		token := tokens[i]
 
-				case 3:
-					grandparent = objTokensSepByDot[0]
-					parent = objTokensSepByDot[1]
-					child = objTokensSepByDot[2]
-
+		switch state {
+		case 0:
+			// Expecting target
+			cmd.t_token = token
+			state = 1
+		case 1:
+			// Expecting object or modifier
+			if OST_IS_VALID_MODIFIER(token) {
+				currentModifier = token
+				fmt.println("current modifier: ", currentModifier)
+				state = 2
+			} else {
+				if strings.contains(token, ".") {
+					cmd.isUsingDotNotation = true
+					objTokensSepByDot := strings.split(strings.trim_space(token), ".")
+					for obj in objTokensSepByDot {
+						append(&cmd.o_token, obj)
+					}
+				} else {
+					append(&cmd.o_token, token)
 				}
 			}
-
-			cmd = types.Command {
-				o_token            = make([dynamic]string),
-				m_token            = make(map[string]string),
-				s_token            = make(map[string]string),
-				isUsingDotNotation = true,
-			}
-
-			currentModifier := "" //stores the current modifier such as TO or WITHIN
-			state := 0 //state machine exclusivley used for modifier token shit
-
-			cmd.a_token = tokens[0] //setting the action token
-			//iterate over remaing ATOM tokens and set/append them to the cmd
-			for j := 1; j < len(tokens); j += 1 {
-				token := tokens[j]
-				switch (state) {
-				case 0:
-					cmd.t_token = token
-					fmt.println("token: ", token)
-					state = 1
-				case 1:
-					//checking if the current token is a modifier; if it is add it to the modifer map
-					if OST_IS_VALID_MODIFIER(token) {
-						currentModifier = token
-						fmt.println("current modifier: ", currentModifier)
-						state = 2
-					} else {
-						for k := 0; k < len(objTokensSepByDot); k += 1 {
-							append(&cmd.o_token, objTokensSepByDot[k])
-						}
-					}
-				case 2:
-					for m := 0; m < len(objTokensSepByDot); m += 1 {
-						cmd.m_token[currentModifier] = token // Preserve original case for modifier values
-						state = 1
-
-					}
-				}
-			}
-		//NOT USING DOT NOTATION // NOT USING DOT NOTATION // NOT USING DOT NOTATION
-		case false:
-			cmd = types.Command {
-				o_token            = make([dynamic]string),
-				m_token            = make(map[string]string),
-				s_token            = make(map[string]string),
-				isUsingDotNotation = false,
-			}
-
-			cmd.a_token = tokens[0]
-
-			state := 0
-			current_modifier := ""
-
-			for i := 1; i < len(tokens); i += 1 {
-				token := strings.to_upper(tokens[i])
-
-				switch state {
-				case 0:
-					// Expecting target
-					cmd.t_token = token
-					state = 1
-				case 1:
-					// Expecting object or modifier
-					if OST_IS_VALID_MODIFIER(token) {
-						current_modifier = token
-						state = 2
-					} else {
-						append(&cmd.o_token, tokens[i]) // Preserve original case for objects
-					}
-				case 2:
-					// Expecting object after modifier
-					cmd.m_token[current_modifier] = tokens[i] // Preserve original case for modifier values
-					state = 1
-				}
-			}
-			return cmd
+		case 2:
+			// Expecting object after modifier
+			cmd.m_token[currentModifier] = token // Preserve original case for modifier values
+			state = 1
 		}
 	}
+
 	return cmd
 }

--- a/src/core/types/types.odin
+++ b/src/core/types/types.odin
@@ -16,11 +16,12 @@ Helpful Hint: Commands are built of ATOMs (A)ction, (T)arget, (O)bject, (M)odifi
 Usage Locations: commands.odin & parser.odin
 */
 Command :: struct {
-	a_token: string, //action token
-	t_token: string, //object token
-	o_token: [dynamic]string, //target token
-	m_token: map[string]string, //modifier token
-	s_token: map[string]string, //scope token
+	a_token:            string, //action token
+	t_token:            string, //object token
+	o_token:            [dynamic]string, //target token
+	m_token:            map[string]string, //modifier token
+	s_token:            map[string]string, //scope token
+	isUsingDotNotation: bool, //if the command is using dot notation
 }
 //=================================================/src/core/data/=================================================//
 /*

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-Pre_Rel_v0.3.2_dev
+Pre_Rel_v0.4.0_dev


### PR DESCRIPTION
This pull request adds the following changes:

- Feature: Added dot notation syntax!
- Rework and clean the parser
- Update several core procedures to work with new dot notation syntax
- Add FETCH & ERASE command use on records
- Fix odd bug that was allowing the OST_RENAME_CLUSTER procedure to work on Linux but not MacOS...This should not have been working on any system at all but it was
- Minor updates to the OstrichDB command line itself
- Remove trash
- Bump version to 0.4

- closes #77
- closes #133