### PR TITLE
Implement COUNT command

### DIFF
--- a/src/core/const/constants.odin
+++ b/src/core/const/constants.odin
@@ -42,6 +42,7 @@ BACKUP :: "BACKUP"
 ERASE :: "ERASE"
 RENAME :: "RENAME"
 FETCH :: "FETCH"
+COUNT :: "COUNT"
 SET :: "SET"
 FOCUS :: "FOCUS"
 UNFOCUS :: "UNFOCUS"
@@ -52,6 +53,10 @@ RECORD :: "RECORD"
 USER :: "USER"
 ALL :: "ALL"
 CONFIG :: "CONFIG" //special target exclusive to SET command
+//Special Target Tokens for the COUNT command
+COLLECTIONS :: "COLLECTIONS"
+CLUSTERS :: "CLUSTERS"
+RECORDS :: "RECORDS"
 //Modifier Tokens
 AND :: "AND"
 OF_TYPE :: "OF_TYPE"

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -794,9 +794,6 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.CLUSTER:
-			//todo: declaring these two variables but not actually using them - Marshall Burns aka @SchoolyB 06Oct2024
-			collection_name: string
-			cluster_name: string
 			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
 			   cmd.isUsingDotNotation == true {
 				collection := cmd.o_token[0]
@@ -1192,8 +1189,6 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 				types.focus.flag = false
 				break
 			}
-
-		//todo: come back to this..havent done enough commands to test this in focus mode yet
 		case const.RECORD:
 			types.focus.flag = true
 			if len(cmd.o_token) >= 3 && const.WITHIN in cmd.m_token {

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -937,6 +937,178 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			)
 			fmt.printfln("The SET command can only be used on RECORDS and CONFIGS")
 		}
+	case const.COUNT:
+		utils.log_runtime_event("Used COUNT command", "")
+		switch (cmd.t_token) 
+		{
+		case const.COLLECTIONS:
+			result := data.OST_COUNT_COLLECTIONS()
+			fmt.printfln("There are %d collections in the database", result)
+			break
+		case const.CLUSTERS:
+			fmt.println("cmd,o_tokens: ", cmd.o_token)
+			if len(cmd.o_token) == 1 {
+				collection_name := cmd.o_token[0]
+				result := data.OST_COUNT_CLUSTERS(collection_name)
+				switch (result) 
+				{
+				case -1:
+					fmt.printfln(
+						"Failed to count clusters in collection %s%s%s",
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					break
+				case 0:
+					fmt.printfln(
+						"There are no clusters in the collection %s%s%s",
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					break
+				case 1:
+					fmt.printfln(
+						"There is %d cluster in the collection %s%s%s",
+						result,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					break
+				case:
+					fmt.printfln(
+						"There are %d clusters in the collection %s%s%s",
+						result,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					break
+				}
+			} else {
+				fmt.printfln(
+					"Invalid command structure. Correct Usage: COUNT CLUSTERS WITHIN COLLECTION <collection_name>\nIf using dot notation: COUNT CLUSTERS <collection_name>",
+				)
+				utils.log_runtime_event(
+					"Invalid COUNT command",
+					"User did not provide a valid collection name to count clusters.",
+				)
+			}
+
+			break
+		case const.RECORDS:
+			//in the event the users is counting the records in a specific cluster
+			if (len(cmd.o_token) >= 2 || cmd.isUsingDotNotation == true) {
+				collection_name := cmd.o_token[0]
+				cluster_name := cmd.o_token[1]
+				result := data.OST_COUNT_RECORDS_IN_CLUSTER(
+					strings.clone(collection_name),
+					strings.clone(cluster_name),
+					true,
+				)
+				switch result {
+				case -1:
+					fmt.printfln(
+						"Error counting records in the cluster %s%s%s collection %s%s%s",
+						utils.BOLD_UNDERLINE,
+						cluster_name,
+						utils.RESET,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+				case 0:
+					fmt.printfln(
+						"There are no records in the cluster %s%s%s in the collection %s%s%s",
+						utils.BOLD_UNDERLINE,
+						cluster_name,
+						utils.RESET,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					break
+				case 1:
+					fmt.printfln(
+						"There is %d record in the cluster %s%s%s in the collection %s%s%s",
+						result,
+						utils.BOLD_UNDERLINE,
+						cluster_name,
+						utils.RESET,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					break
+				case:
+					fmt.printfln(
+						"There are %d records in the cluster %s%s%s in the collection %s%s%s",
+						result,
+						utils.BOLD_UNDERLINE,
+						cluster_name,
+						utils.RESET,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					return 0
+				}
+			} else if len(cmd.o_token) == 1 || cmd.isUsingDotNotation == true {
+				//in the event the user is counting all records in a collection
+				collection_name := cmd.o_token[0]
+				result := data.OST_COUNT_RECORDS_IN_COLLECTION(collection_name)
+
+				switch result 
+				{
+				case -1:
+					fmt.printfln(
+						"Error counting records in the collection %s%s%s",
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					break
+				case 0:
+					fmt.printfln(
+						"There are no records in collection %s%s%s",
+						utils.BOLD,
+						collection_name,
+						utils.RESET,
+					)
+					break
+				case 1:
+					fmt.printfln(
+						"There is %d record in the collection %s%s%s",
+						result,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+					break
+				case:
+					fmt.printfln(
+						"There are %d records in the collection %s%s%s",
+						result,
+						utils.BOLD_UNDERLINE,
+						collection_name,
+						utils.RESET,
+					)
+				}
+
+			} else {
+				fmt.printfln(
+					"Invalid command structure. Correct Usage: COUNT RECORDS WITHIN CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>\nIf using dot notation: COUNT RECORDS <collection_name>.<cluster_name>",
+				)
+				utils.log_runtime_event(
+					"Invalid COUNT command",
+					"User did not provide a valid cluster name to count records.",
+				)
+			}
+			break
+		}
+		break
 	//FOCUS and UNFOCUS: Enter at own peril.
 	case const.FOCUS:
 		utils.log_runtime_event("Used FOCUS command", "")
@@ -1073,6 +1245,8 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			break
 		}
 		break
+
+
 	case:
 		fmt.printfln(
 			"Invalid command: %s%s%s. Please enter a valide OstrichDB command. Enter 'HELP' for more information.",

--- a/src/core/engine/data/clusters.odin
+++ b/src/core/engine/data/clusters.odin
@@ -897,3 +897,35 @@ OST_SCAN_CLUSTER_STRUCTURE :: proc(fn: string) -> (scanSuccess: int, invalidStru
 
 	return 0, false
 }
+
+//TODO: FIX ME  ;)
+//counts the number of clusters in a collection file
+OST_COUNT_CLUSTERS :: proc(fn: string) -> int {
+    file := fmt.tprintf("%s%s%s", const.OST_COLLECTION_PATH, fn, const.OST_FILE_EXTENSION)
+
+    data, read_success := os.read_entire_file(file)
+    if !read_success {
+        utils.log_err("Failed to read collection file", #procedure)
+        return 0
+    }
+    defer delete(data)
+
+    content := string(data)
+    cluster_count := 0
+    in_cluster := false
+
+    lines := strings.split(content, "\n")
+    defer delete(lines)
+
+    for line in lines {
+        trimmed := strings.trim_space(line)
+        if trimmed == "{" {
+            in_cluster = true
+            cluster_count += 1
+        } else if trimmed == "}," {
+            in_cluster = false
+        }
+    }
+
+    return cluster_count
+}

--- a/src/core/engine/data/clusters.odin
+++ b/src/core/engine/data/clusters.odin
@@ -22,7 +22,6 @@ main :: proc() {
 	os.make_directory(const.OST_QUARANTINE_PATH)
 	os.make_directory(const.OST_COLLECTION_PATH)
 	metadata.OST_CREATE_FFVF()
-	test := metadata.OST_GET_FILE_FORMAT_VERSION() //todo: remove this line
 }
 
 //creates a cache used to store all generated cluster ids
@@ -898,34 +897,33 @@ OST_SCAN_CLUSTER_STRUCTURE :: proc(fn: string) -> (scanSuccess: int, invalidStru
 	return 0, false
 }
 
-//TODO: FIX ME  ;)
 //counts the number of clusters in a collection file
 OST_COUNT_CLUSTERS :: proc(fn: string) -> int {
-    file := fmt.tprintf("%s%s%s", const.OST_COLLECTION_PATH, fn, const.OST_FILE_EXTENSION)
+	file := fmt.tprintf("%s%s%s", const.OST_COLLECTION_PATH, fn, const.OST_FILE_EXTENSION)
 
-    data, read_success := os.read_entire_file(file)
-    if !read_success {
-        utils.log_err("Failed to read collection file", #procedure)
-        return 0
-    }
-    defer delete(data)
+	data, read_success := os.read_entire_file(file)
+	if !read_success {
+		utils.log_err("Failed to read collection file", #procedure)
+		return 0
+	}
+	defer delete(data)
 
-    content := string(data)
-    cluster_count := 0
-    in_cluster := false
+	content := string(data)
+	cluster_count := 0
+	in_cluster := false
 
-    lines := strings.split(content, "\n")
-    defer delete(lines)
+	lines := strings.split(content, "\n")
+	defer delete(lines)
 
-    for line in lines {
-        trimmed := strings.trim_space(line)
-        if trimmed == "{" {
-            in_cluster = true
-            cluster_count += 1
-        } else if trimmed == "}," {
-            in_cluster = false
-        }
-    }
+	for line in lines {
+		trimmed := strings.trim_space(line)
+		if trimmed == "{" {
+			in_cluster = true
+			cluster_count += 1
+		} else if trimmed == "}," {
+			in_cluster = false
+		}
+	}
 
-    return cluster_count
+	return cluster_count
 }

--- a/src/core/engine/data/collections.odin
+++ b/src/core/engine/data/collections.odin
@@ -408,3 +408,19 @@ OST_FIND_SEC_COLLECTION :: proc(fn: string) -> (found: bool, name: string) {
 	}
 	return found, ""
 }
+
+//gets the number of collections in the collections directory
+OST_COUNT_COLLECTIONS :: proc() -> int {
+	collectionsDir, errOpen := os.open(const.OST_COLLECTION_PATH)
+	defer os.close(collectionsDir)
+	foundFiles, dirReadSuccess := os.read_dir(collectionsDir, -1)
+	collectionNames := make([dynamic]string)
+	defer delete(collectionNames)
+
+	for file in foundFiles {
+		if strings.contains(file.name, const.OST_FILE_EXTENSION) {
+			append(&collectionNames, file.name)
+		}
+	}
+	return len(collectionNames)
+}

--- a/src/core/engine/engine.odin
+++ b/src/core/engine/engine.odin
@@ -117,6 +117,7 @@ OST_ENGINE_COMMAND_LINE :: proc() -> int {
 		types.current_user.commandHistory.cHistoryCount = data.OST_COUNT_RECORDS_IN_CLUSTER(
 			"history",
 			types.current_user.username.Value,
+			false,
 		)
 		// types.current_user.commandHistory.cHistoryNamePrefix = "history_" dont need this shit tbh - SchoolyB
 		histCountStr := strconv.itoa(histBuf[:], types.current_user.commandHistory.cHistoryCount)


### PR DESCRIPTION
This pull request contains the following changes:

- Added 3 new constants (COLLECTIONS, CLUSTERS, and RECORDS)
- Implemented `COUNT` command on collections, clusters, and records
- Updated the `OST_COUNT_RECORDS_IN_COLLECTION()` proc
- Removed trash
- closes #139 