### PR TITLE
Deprecate WITHIN modifier token

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,16 @@ Commands in OstrichDB are parsed into tokens also called ATOMs. This structured 
 - **(A)ction token**: Specifies the operation to be performed (e.g., NEW, ERASE, RENAME)
 - **(T)arget token**: Indicates the type of object the action is performed on (e.g., CLUSTER, RECORD)
 - **(O)bject token**: Represents the name or identifier of the target
-- **(M)odifier**: Additional parameters that modify the command's behavior (e.g., WITHIN)
+- **(M)odifier**: Additional parameters that modify the command's behavior (e.g., TO)
 
 Note: Not all commands require all ATOMs. The number of ATOMs required depends on the command and its context.
 
-Example: `NEW CLUSTER foo WITHIN COLLECTION bar`
+Example: `RENAME CLUSTER foo TO bar`
 
 In this example:
 - `NEW` is the Action token
 - `CLUSTER` is the Target token
 - `foo` is the Object token (name of the cluster) given by the user
-- `WITHIN` is a special modifier called a scope modifier
 - `COLLECTION bar` specifies where the new cluster should be created
 
 ## Supported Commands
@@ -70,15 +69,14 @@ In this example:
 
 Example usage of multi-token commands:
 ```bash
-NEW CLUSTER <cluster_name> WITHIN COLLECTION <collection_name> //Creates a new cluster within the specified collection
-ERASE CLUSTER <cluster_name> WITHIN COLLECTION <collection_name> //Erase the cluster with the specified name
+NEW COLLECTION <collection_name> //Creates a new collection
 RENAME RECORD <old_name> TO <new_name> //Renames the record with the specified old name to the new name
 FETCH COLLECTION <collection_name> //Fetches all data within the collection of specified name
 SET RECORD <record_name> TO <value> //Sets the value of the specified record
 BACKUP COLLECTION <collection_name> //Creates a backup of the specified collection
 HELP COLLECTION //Displays information about collections
 NEW RECORD <record_name> OF_TYPE <record_type>
-FOCUS CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>  //Focuses on the specified cluster within the specified collection
+FOCUS COLLECTION <collection_name> //Focuses on the specified collection
 ```
 
 **Note: The `FOCUS` command is used to set the current context to a specific object. ALL subsequent commands will be executed in the context of the focused object.**
@@ -87,7 +85,6 @@ FOCUS CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>  //Focuses on t
 
 Modifiers are additional parameters that modify the behavior of a command:
 
-- `WITHIN`: A scope modifier used to specify the parent object of the target object
 - `TO`: Used with the RENAME and SET command to specify the new name or value of the object
 - `ATOMS`: A special modifier ONLY used with the HELP command to display detailed information about the command's ATOMs
 - `OF_TYPE`: ONLY used with the NEW RECORD command to specify the type of record being created

--- a/src/core/const/constants.odin
+++ b/src/core/const/constants.odin
@@ -67,9 +67,6 @@ OF_TYPE :: "OF_TYPE"
 TYPE :: "TYPE"
 ALL_OF :: "ALL_OF"
 TO :: "TO"
-//Scope Tokens
-WITHIN :: "WITHIN"
-IN :: "IN"
 //Type Tokens
 STRING :: "STRING"
 STR :: "STR"

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -330,15 +330,10 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 		case const.CLUSTER:
 			cluster_name: string
 			collection_name: string
-			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
-			   cmd.isUsingDotNotation == true {
-				//using dot notation
+			if len(cmd.o_token) >= 2 && cmd.isUsingDotNotation == true {
 				if cmd.isUsingDotNotation == true {
 					collection_name = cmd.o_token[0]
 					cluster_name = cmd.o_token[1]
-				} else { 	//using within
-					cluster_name = cmd.o_token[0]
-					collection_name = cmd.o_token[1]
 				}
 				fmt.printf(
 					"Creating cluster: %s%s%s within collection: %s%s%s\n",
@@ -389,7 +384,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 				metadata.OST_UPDATE_METADATA_VALUE(fn, 3)
 			} else {
 				fmt.printfln(
-					"Incomplete command. Correct Usage: NEW CLUSTER <cluster_name> WITHIN COLLECTION <collection_name> \nAlternatively, you can use dot notation: NEW CLUSTER <collection_name>.<cluster_name>",
+					"Invalid command. Correct Usage: NEW CLUSTER <collection_name>.<cluster_name>",
 				)
 				utils.log_runtime_event(
 					"Incomplete NEW command",
@@ -506,7 +501,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 
 			} else {
 				fmt.printfln(
-					"Incomplete command. Correct Usage: NEW RECORD <record_name> OF_TYPE <record_type>\nAlternatively, you can use dot notation: NEW RECORD <collection_name>.<cluster_name>.<record_name> OF_TYPE <record_type>",
+					"Incomplete command. Correct Usage: NEW RECORD <collection_name>.<cluster_name>.<record_name> OF_TYPE <record_type>",
 				)
 				utils.log_runtime_event(
 					"Incomplete NEW RECORD command",
@@ -596,9 +591,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			cluster_name: string
 			collection_name: string
 
-			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token && const.TO in cmd.m_token ||
-			   cmd.isUsingDotNotation == true {
-				// if cmd.isUsingDotNotation == true {}
+			if len(cmd.o_token) >= 2 && const.TO in cmd.m_token && cmd.isUsingDotNotation == true {
 				old_name := cmd.o_token[1]
 				collection_name := cmd.o_token[0]
 				new_name := cmd.m_token[const.TO]
@@ -638,7 +631,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 				}
 			} else {
 				fmt.println(
-					"Incomplete command. Correct Usage: RENAME CLUSTER <old_name> WITHIN <collection_name> TO <new_name>",
+					"Incomplete command. Correct Usage: RENAME CLUSTER <collection_name>.<old_name> TO <new_name>",
 				)
 				utils.log_runtime_event(
 					"Incomplete RENAME command",
@@ -706,7 +699,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 
 			} else {
 				fmt.println(
-					"Incomplete command. Correct Usage: RENAME RECORD <old_name> TO <new_name>\nAlternativley use dot notation: RENAME RECORD <collection_name>.<cluster_name>.<old_name> TO <new_name>",
+					"Incomplete command. Correct Usage: RENAME RECORD <collection_name>.<cluster_name>.<old_name> TO <new_name>",
 				)
 				utils.log_runtime_event(
 					"Incomplete RENAME command",
@@ -743,8 +736,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			collection_name: string
 			cluster_name: string
 
-			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
-			   cmd.isUsingDotNotation == true {
+			if len(cmd.o_token) >= 2 && cmd.isUsingDotNotation == true {
 				collection_name := cmd.o_token[0]
 				cluster := cmd.o_token[1]
 				clusterID := data.OST_GET_CLUSTER_ID(collection_name, cluster)
@@ -782,7 +774,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 				metadata.OST_UPDATE_METADATA_VALUE(fn, 3)
 			} else {
 				fmt.println(
-					"Incomplete command. Correct Usage: ERASE CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>",
+					"Incomplete command. Correct Usage: ERASE CLUSTER <collection_name>.<cluster_name>",
 				)
 				utils.log_runtime_event(
 					"Incomplete ERASE command",
@@ -795,8 +787,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			cluster_name: string
 			record_name: string
 
-			if len(cmd.o_token) == 3 && const.WITHIN in cmd.m_token ||
-			   cmd.isUsingDotNotation == true {
+			if len(cmd.o_token) == 3 && cmd.isUsingDotNotation == true {
 				collection_name := cmd.o_token[0]
 				cluster_name := cmd.o_token[1]
 				record_name := cmd.o_token[2]
@@ -841,7 +832,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			break
 		case:
 			fmt.printfln(
-				"Invalid command structure. Correct Usage: ERASE <Target> <Targets_name>\nAlternativley use dot notation: ERASE <collection_name>.<cluster_name>.<record_name>",
+				"Invalid command structure. Correct Usage: ERASE <collection_name>.<cluster_name>.<record_name>",
 			)
 			utils.log_runtime_event(
 				"Invalid ERASE command",
@@ -870,8 +861,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			}
 			break
 		case const.CLUSTER:
-			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
-			   cmd.isUsingDotNotation == true {
+			if len(cmd.o_token) >= 2 && cmd.isUsingDotNotation == true {
 				collection := cmd.o_token[0]
 				cluster := cmd.o_token[1]
 				checks := data.OST_HANDLE_INTEGRITY_CHECK_RESULT(collection)
@@ -885,7 +875,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 				fmt.printfln(clusterContent)
 			} else {
 				fmt.println(
-					"Incomplete command. Correct Usage: FETCH CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>",
+					"Incomplete command. Correct Usage: FETCH CLUSTER <collection_name>.<cluster_name>",
 				)
 				utils.log_runtime_event(
 					"Incomplete FETCH command",
@@ -897,8 +887,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 			colllection_name: string
 			cluster_name: string
 			record_name: string
-			if len(cmd.o_token) == 3 && const.WITHIN in cmd.m_token ||
-			   cmd.isUsingDotNotation == true {
+			if len(cmd.o_token) == 3 && cmd.isUsingDotNotation == true {
 				collection_name := cmd.o_token[0]
 				cluster_name := cmd.o_token[1]
 				record_name := cmd.o_token[2]
@@ -929,7 +918,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 				}
 			} else {
 				fmt.printfln(
-					"Incomplete command. Correct Usage: FETCH RECORD <record_name> WITHIN CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>",
+					"Incomplete command. Correct Usage: FETCH RECORD <collection_name>.<cluster_name>.<record_name>",
 				)
 				utils.log_runtime_event(
 					"Incomplete FETCH command",
@@ -1062,7 +1051,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 				}
 			} else {
 				fmt.printfln(
-					"Invalid command structure. Correct Usage: COUNT CLUSTERS WITHIN COLLECTION <collection_name>\nIf using dot notation: COUNT CLUSTERS <collection_name>",
+					"Invalid command structure. Correct Usage: COUNT CLUSTERS <collection_name>",
 				)
 				utils.log_runtime_event(
 					"Invalid COUNT command",
@@ -1172,7 +1161,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 
 			} else {
 				fmt.printfln(
-					"Invalid command structure. Correct Usage: COUNT RECORDS WITHIN CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>\nIf using dot notation: COUNT RECORDS <collection_name>.<cluster_name>",
+					"Invalid command structure. Correct Usage: COUNT RECORDS <collection_name>.<cluster_name>",
 				)
 				utils.log_runtime_event(
 					"Invalid COUNT command",
@@ -1231,9 +1220,7 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 		case const.CLUSTER:
 			collection_name := cmd.o_token[0]
 			cluster_name := cmd.o_token[1]
-			if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token ||
-			   cmd.isUsingDotNotation == true {
-
+			if len(cmd.o_token) >= 2 && cmd.isUsingDotNotation == true {
 				result := data.OST_PURGE_CLUSTER(collection_name, cluster_name)
 				switch result {
 				case true:
@@ -1389,139 +1376,139 @@ OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
 		}
 		break
 	//FOCUS and UNFOCUS: Enter at own peril.
-	case const.FOCUS:
-		utils.log_runtime_event("Used FOCUS command", "")
+	// case const.FOCUS:
+	// 	utils.log_runtime_event("Used FOCUS command", "")
 
-		switch (cmd.t_token) 
-		{
-		case const.COLLECTION:
-			exists := data.OST_CHECK_IF_COLLECTION_EXISTS(cmd.o_token[0], 0)
-			fmt.println(exists)
-			switch exists {
-			case true:
-				types.focus.flag = true
-				if len(cmd.o_token) > 0 {
-					collection := cmd.o_token[0]
-					storedT, storedO, _ := OST_FOCUS(const.COLLECTION, collection, "[NO PARENT]")
-				} else {
-					fmt.println(
-						invalidCommandErr,
-						"Incomplete command. Correct Usage: NEW COLLECTION <collection_name>",
-					)
-					utils.log_runtime_event(
-						"Incomplete FOCUS command",
-						"User did not provide a valid collection name to focus.",
-					)
-				}
-				break
-			case false:
-				fmt.printfln(
-					"Collection: %s%s%s not found in OstrichDB.",
-					utils.BOLD_UNDERLINE,
-					cmd.o_token[0],
-					utils.RESET,
-				)
-				utils.log_runtime_event(
-					"Invalid FOCUS command",
-					"User tried to focus on a collection that does not exist.",
-				)
-				types.focus.flag = false
-				break
-			}
+	// 	switch (cmd.t_token)
+	// 	{
+	// 	case const.COLLECTION:
+	// 		exists := data.OST_CHECK_IF_COLLECTION_EXISTS(cmd.o_token[0], 0)
+	// 		fmt.println(exists)
+	// 		switch exists {
+	// 		case true:
+	// 			types.focus.flag = true
+	// 			if len(cmd.o_token) > 0 {
+	// 				collection := cmd.o_token[0]
+	// 				storedT, storedO, _ := OST_FOCUS(const.COLLECTION, collection, "[NO PARENT]")
+	// 			} else {
+	// 				fmt.println(
+	// 					invalidCommandErr,
+	// 					"Incomplete command. Correct Usage: NEW COLLECTION <collection_name>",
+	// 				)
+	// 				utils.log_runtime_event(
+	// 					"Incomplete FOCUS command",
+	// 					"User did not provide a valid collection name to focus.",
+	// 				)
+	// 			}
+	// 			break
+	// 		case false:
+	// 			fmt.printfln(
+	// 				"Collection: %s%s%s not found in OstrichDB.",
+	// 				utils.BOLD_UNDERLINE,
+	// 				cmd.o_token[0],
+	// 				utils.RESET,
+	// 			)
+	// 			utils.log_runtime_event(
+	// 				"Invalid FOCUS command",
+	// 				"User tried to focus on a collection that does not exist.",
+	// 			)
+	// 			types.focus.flag = false
+	// 			break
+	// 		}
 
-		case const.CLUSTER:
-			collectionNamePath := fmt.tprintf("%s%s", const.OST_COLLECTION_PATH, cmd.o_token[1])
-			fullCollectionPath := fmt.tprintf("%s%s", collectionNamePath, const.OST_FILE_EXTENSION)
+	// 	case const.CLUSTER:
+	// 		collectionNamePath := fmt.tprintf("%s%s", const.OST_COLLECTION_PATH, cmd.o_token[1])
+	// 		fullCollectionPath := fmt.tprintf("%s%s", collectionNamePath, const.OST_FILE_EXTENSION)
 
-			checks := data.OST_HANDLE_INTEGRITY_CHECK_RESULT(cmd.o_token[1])
-			switch (checks) 
-			{
-			case -1:
-				return -1
-			}
+	// 		checks := data.OST_HANDLE_INTEGRITY_CHECK_RESULT(cmd.o_token[1])
+	// 		switch (checks)
+	// 		{
+	// 		case -1:
+	// 			return -1
+	// 		}
 
-			exists := data.OST_CHECK_IF_CLUSTER_EXISTS(fullCollectionPath, cmd.o_token[0])
-			switch exists {
-			case true:
-				types.focus.flag = true
-				if len(cmd.o_token) >= 2 && const.WITHIN in cmd.m_token {
-					cluster := cmd.o_token[0]
-					collection := cmd.o_token[1]
-					storedT, storedO, _ := OST_FOCUS(const.CLUSTER, cluster, cmd.o_token[1]) //storing the Target and Objec that the user wants to focus)
-				} else {
-					fmt.println(
-						"Incomplete command. Correct Usage: FOCUS CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>",
-					)
-					utils.log_runtime_event(
-						"Incomplete FOCUS command",
-						"User did not provide a valid cluster name to focus.",
-					)
-				}
-				break
-			case false:
-				fmt.printfln(
-					"Cluster: %s%s%s does not exist within collection: %s%s%s.",
-					utils.BOLD,
-					cmd.o_token[0],
-					utils.RESET,
-					utils.BOLD,
-					cmd.o_token[1],
-					utils.RESET,
-				)
-				types.focus.flag = false
-				break
-			}
-		case const.RECORD:
-			types.focus.flag = true
-			if len(cmd.o_token) >= 3 && const.WITHIN in cmd.m_token {
-				record := cmd.o_token[0]
-				cluster := cmd.o_token[1]
-				collection := cmd.o_token[2]
+	// 		exists := data.OST_CHECK_IF_CLUSTER_EXISTS(fullCollectionPath, cmd.o_token[0])
+	// 		switch exists {
+	// 		case true:
+	// 			types.focus.flag = true
+	// 			if len(cmd.o_token) >= 2 && isUSingDotNotation == true {
+	// 				cluster := cmd.o_token[0]
+	// 				collection := cmd.o_token[1]
+	// 				storedT, storedO, _ := OST_FOCUS(const.CLUSTER, cluster, cmd.o_token[1]) //storing the Target and Objec that the user wants to focus)
+	// 			} else {
+	// 				fmt.println(
+	// 					"Incomplete command. Correct Usage: FOCUS CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>",
+	// 				)
+	// 				utils.log_runtime_event(
+	// 					"Incomplete FOCUS command",
+	// 					"User did not provide a valid cluster name to focus.",
+	// 				)
+	// 			}
+	// 			break
+	// 		case false:
+	// 			fmt.printfln(
+	// 				"Cluster: %s%s%s does not exist within collection: %s%s%s.",
+	// 				utils.BOLD,
+	// 				cmd.o_token[0],
+	// 				utils.RESET,
+	// 				utils.BOLD,
+	// 				cmd.o_token[1],
+	// 				utils.RESET,
+	// 			)
+	// 			types.focus.flag = false
+	// 			break
+	// 		}
+	// 	case const.RECORD:
+	// 		types.focus.flag = true
+	// 		if len(cmd.o_token) >= 3 && isUsingDotNotation == true {
+	// 			record := cmd.o_token[0]
+	// 			cluster := cmd.o_token[1]
+	// 			collection := cmd.o_token[2]
 
-				checks := data.OST_HANDLE_INTEGRITY_CHECK_RESULT(collection)
-				switch (checks) 
-				{
-				case -1:
-					return -1
-				}
+	// 			checks := data.OST_HANDLE_INTEGRITY_CHECK_RESULT(collection)
+	// 			switch (checks)
+	// 			{
+	// 			case -1:
+	// 				return -1
+	// 			}
 
-				storedParentT, storedParentO, storedRO := OST_FOCUS_RECORD(
-					collection,
-					cluster,
-					record,
-				)
-				fmt.printfln(
-					"Focused on record: %s%s%s in cluster: %s%s%s within collection: %s%s%s",
-					utils.BOLD_UNDERLINE,
-					record,
-					utils.RESET,
-					utils.BOLD_UNDERLINE,
-					cluster,
-					utils.RESET,
-					utils.BOLD_UNDERLINE,
-					collection,
-					utils.RESET,
-				)
-				//storing the Target and Objec that the user wants to focus)
-			} else {
-				fmt.printfln(
-					"Incomplete command. Correct Usage: FOCUS RECORD <record_name> WITHIN CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>",
-				)
-				utils.log_runtime_event(
-					"Incomplete FOCUS command",
-					"User did not provide a valid record name to focus.",
-				)
-			}
-			break
-		case:
-			fmt.printfln("Invalid command structure. Correct Usage: FOCUS <target> <target_name>")
-			utils.log_runtime_event(
-				"Invalid FOCUS command",
-				"User did not provide a valid target.",
-			)
-			break
-		}
-		break
+	// 			storedParentT, storedParentO, storedRO := OST_FOCUS_RECORD(
+	// 				collection,
+	// 				cluster,
+	// 				record,
+	// 			)
+	// 			fmt.printfln(
+	// 				"Focused on record: %s%s%s in cluster: %s%s%s within collection: %s%s%s",
+	// 				utils.BOLD_UNDERLINE,
+	// 				record,
+	// 				utils.RESET,
+	// 				utils.BOLD_UNDERLINE,
+	// 				cluster,
+	// 				utils.RESET,
+	// 				utils.BOLD_UNDERLINE,
+	// 				collection,
+	// 				utils.RESET,
+	// 			)
+	// 			//storing the Target and Objec that the user wants to focus)
+	// 		} else {
+	// 			fmt.printfln(
+	// 				"Incomplete command. Correct Usage: FOCUS RECORD <record_name> WITHIN CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>",
+	// 			)
+	// 			utils.log_runtime_event(
+	// 				"Incomplete FOCUS command",
+	// 				"User did not provide a valid record name to focus.",
+	// 			)
+	// 		}
+	// 		break
+	// 	case:
+	// 		fmt.printfln("Invalid command structure. Correct Usage: FOCUS <target> <target_name>")
+	// 		utils.log_runtime_event(
+	// 			"Invalid FOCUS command",
+	// 			"User did not provide a valid target.",
+	// 		)
+	// 		break
+	// 	}
+	// 	break
 
 
 	case:

--- a/src/core/engine/parser.odin
+++ b/src/core/engine/parser.odin
@@ -14,7 +14,7 @@ import "core:strings"
 
 OST_IS_VALID_MODIFIER :: proc(token: string) -> bool {
 	using const
-	validModifiers := []string{AND, WITHIN, IN, OF_TYPE, TYPE, ALL_OF, TO}
+	validModifiers := []string{AND, OF_TYPE, TYPE, ALL_OF, TO}
 	for modifier in validModifiers {
 		if strings.to_upper(token) == modifier {
 			return true
@@ -41,7 +41,7 @@ OST_PARSE_COMMAND :: proc(input: string) -> types.Command {
 
 	cmd.a_token = tokens[0] //setting the action token
 	state := 0 //state machine exclusively used for modifier token shit
-	currentModifier := "" //stores the current modifier such as TO or WITHIN
+	currentModifier := "" //stores the current modifier such as TO
 
 	//iterate over remaining ATOM tokens and set/append them to the cmd
 	for i := 1; i < len(tokens); i += 1 {

--- a/src/core/help/docs/atoms/atoms.txt
+++ b/src/core/help/docs/atoms/atoms.txt
@@ -19,5 +19,4 @@
 |CLUSTER    |Target         |                 |Specifies that the target is a cluster                              |
 |RECORD     |Target         |                 |Specifies that the target is a record                               |
 |TO         |Modifier       |                 |Used with the RENAME action to specify the new name of the target   |
-|WITHIN     |Scope Modifier |                 |Specifies the scope of the target in which the action should be performed|
 |ATOM/ATOMS |Help Target    |                 |Only Used with the HELP action to show information about atoms|

--- a/src/core/help/docs/general/general.md
+++ b/src/core/help/docs/general/general.md
@@ -81,11 +81,6 @@ Backups are stored in `/bin/backups` with `.ost` extension.
 
 ## Modifiers
 
-### WITHIN
-A scope modifier specifying location.
-Syntax: `<action> <object> WITHIN <parent_object>`
-Example: `NEW CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>`
-
 ### TO
 Used with RENAME to specify the new name.
 Example: `RENAME COLLECTION <old_name> TO <new_name>`

--- a/src/core/help/docs/simple/simple.md
+++ b/src/core/help/docs/simple/simple.md
@@ -72,10 +72,6 @@ Groups of related records within a collection.
 Individual pieces of data stored in clusters.
 ### RECORD END
 
-### WITHIN START
-Specifies location. Use: `<action> <object> WITHIN <parent_object>`.
-### WITHIN END
-
 ### TO START
 Used with RENAME to specify the new name.
 ### TO END

--- a/src/core/help/docs/verbose/verbose.md
+++ b/src/core/help/docs/verbose/verbose.md
@@ -73,10 +73,6 @@ Clusters are objects made up of related data called "records". Clusters are stor
 Records are individual pieces of data that are stored within clusters. Records are similar to "key-value pairs" in JSON. Records are made up of a record name and a record value. Record names are created by the user and record values are the data that is stored within the record itself. Records are the smallest unit of data that can be stored in OstrichDB.
 ### RECORD END
 
-### WITHIN START
-The `WITHIN` token is a special modifier token called a scope modifier. It is used to specify the location of an object(target) within another object(parent). `WITHIN` MUST be followed by a target token such as `COLLECTION` or `CLUSTER` and an object name. This tells the parser to set the scope of the target that the action will be performed on. For example: `NEW CLUSTER <cluster_name> WITHIN COLLECTION <collection_name>` will create a new cluster with the specified name within the specified collection.
-### WITHIN END
-
 ### TO START
 The `TO` token is used with the `RENAME` token to specify the new name of an object. `TO` MUST be followed by the new name of the object. For example: `RENAME COLLECTION <collection_name> TO <new_collection_name>` will rename the collection with the specified name to the new specified name.
 ### TO END

--- a/src/core/help/help.odin
+++ b/src/core/help/help.odin
@@ -32,7 +32,6 @@ validCommands := []string {
 	"ERASE",
 	"RENAME",
 	"FETCH",
-	"WITHIN",
 	"TO",
 }
 //called when user only enters the "HELP" command without any arguments


### PR DESCRIPTION
This pull request contains the following changes:

- Removes the WITHIN constant
- WITHIN is no longer supported from the command line
- Update README with WITHIN modifier token deprecation
- Update help docs with WITHIN modifier token deprecation
- Removes trash TO constant as well

- closes #150 


*Note: I mispelled the branch name*