### PR TITLE
Implement New Metadata Header Format

### DIFF
--- a/src/core/const/constants.odin
+++ b/src/core/const/constants.odin
@@ -161,6 +161,9 @@ VALID_RECORD_TYPES: []string : {
 	TIME,
 	DATETIME,
 }
+
+METADATA_START :: "@@@@@@@@@@@@@@@TOP@@@@@@@@@@@@@@@\n"
+METADATA_END :: "@@@@@@@@@@@@@@@BTM@@@@@@@@@@@@@@@\n"
 MAX_SESSION_TIME: time.Duration : 86400000000000 //1 day in nanoseconds
 MAX_COLLECTION_TO_DISPLAY :: 20 // for TREE command, max number of constants before prompting user to print
 // MAX_SESSION_TIME: time.Duration : 60000000000 //1 minute in nano seconds only used for testing

--- a/src/core/engine/data/collections.odin
+++ b/src/core/engine/data/collections.odin
@@ -298,7 +298,7 @@ OST_RENAME_COLLECTION :: proc(old: string, new: string) -> bool {
 //reads and retuns everything below the metadata header in the .ost file
 OST_FETCH_COLLECTION :: proc(fn: string) -> string {
 	fileStart := -1
-	startingPoint := "# [Ostrich File Header End]},"
+	startingPoint := "BTM@@@@@@@@@@@@@@@" //has to be half of the metadata header end mark and not the full thing..IDK why - Marshall
 	filePath := strings.concatenate([]string{const.OST_COLLECTION_PATH, fn})
 	filePathAndExt := strings.concatenate([]string{filePath, const.OST_FILE_EXTENSION})
 	data, readSuccess := os.read_entire_file(filePathAndExt)

--- a/src/core/engine/data/records.odin
+++ b/src/core/engine/data/records.odin
@@ -1579,8 +1579,8 @@ OST_COUNT_RECORDS_IN_COLLECTION :: proc(fn: string) -> int {
 			   !strings.has_prefix(trimmedLine, "cluster_name") &&
 			   !strings.has_prefix(trimmedLine, "cluster_id") &&
 			   strings.contains(trimmedLine, ":") &&
-			   !strings.contains(trimmedLine, "[Ostrich File Header Start]") &&
-			   !strings.contains(trimmedLine, "[Ostrich File Header End]") {
+			   !strings.contains(trimmedLine, const.METADATA_START) &&
+			   !strings.contains(trimmedLine, const.METADATA_END) {
 				recordCount += 1
 			}
 		}


### PR DESCRIPTION
This pull request contains the following changes:

- Added 2 new constants
  1. `METADATA_START`
  2. `METADATA_END`
- Updated the metadata header structure. This fixes other formatting issues that occur during operations that read for a trailing `},`

- Updated several core procs in `isolate.odin` so that they can now read the new metadata format

- closes #184 