### PR TITLE
Fix bug that prevented accurate record count

### DIFF
--- a/src/core/const/constants.odin
+++ b/src/core/const/constants.odin
@@ -165,6 +165,7 @@ VALID_RECORD_TYPES: []string : {
 
 METADATA_START :: "@@@@@@@@@@@@@@@TOP@@@@@@@@@@@@@@@\n"
 METADATA_END :: "@@@@@@@@@@@@@@@BTM@@@@@@@@@@@@@@@\n"
+
 MAX_SESSION_TIME: time.Duration : 86400000000000 //1 day in nanoseconds
 MAX_COLLECTION_TO_DISPLAY :: 20 // for TREE command, max number of constants before prompting user to print
 // MAX_SESSION_TIME: time.Duration : 60000000000 //1 minute in nano seconds only used for testing

--- a/src/core/engine/commands.odin
+++ b/src/core/engine/commands.odin
@@ -23,6 +23,7 @@ import "core:strings"
 
 
 OST_EXECUTE_COMMAND :: proc(cmd: ^types.Command) -> int {
+	//TODO: not even using these...
 	incompleteCommandErr := utils.new_err(
 		.INCOMPLETE_COMMAND,
 		utils.get_err_msg(.INCOMPLETE_COMMAND),

--- a/src/core/engine/data/records.odin
+++ b/src/core/engine/data/records.odin
@@ -1509,6 +1509,12 @@ OST_COUNT_RECORDS_IN_CLUSTER :: proc(fn, cn: string, isCounting: bool) -> int {
 		)
 	} else if isCounting == false {
 		collectionPath = fmt.tprintf("%s%s%s", const.OST_CORE_PATH, fn, const.OST_FILE_EXTENSION)
+		fmt.printfln(
+			"%s procedure is counting records in cluster: %s within collection: %s",
+			#procedure,
+			cn,
+			fn,
+		)
 	}
 
 	data, readSuccess := utils.read_file(collectionPath, #procedure)
@@ -1519,21 +1525,27 @@ OST_COUNT_RECORDS_IN_CLUSTER :: proc(fn, cn: string, isCounting: bool) -> int {
 
 	content := string(data)
 	clusters := strings.split(content, "},")
-	// fmt.printfln("clusters: %s", clusters)
+	// fmt.printfln("clusters: %s", clusters) //debugging
 	for cluster in clusters {
 		if strings.contains(cluster, fmt.tprintf("cluster_name :identifier: %s", cn)) {
 			lines := strings.split(cluster, "\n")
 			recordCount := 0
 
 			for line in lines {
+				// fmt.printfln("line: %s", line) //debugging
 				trimmedLine := strings.trim_space(line)
 				if len(trimmedLine) > 0 &&
 				   !strings.has_prefix(trimmedLine, "cluster_name") &&
 				   !strings.has_prefix(trimmedLine, "cluster_id") &&
+				   !strings.contains(trimmedLine, "#") &&
+				   !strings.contains(trimmedLine, const.METADATA_START) &&
+				   !strings.contains(trimmedLine, const.METADATA_END) &&
 				   strings.contains(trimmedLine, ":") {
+					// fmt.printfln("trimmedLine: %s", trimmedLine) //debugging
 					recordCount += 1
 				}
 			}
+			// fmt.printfln("Record count: %d", recordCount) //debugging
 			return recordCount
 		}
 	}


### PR DESCRIPTION
- Updated `OST_COUNT_RECORDS_IN_CLUSTER()` proc to properly count records after metadata header format change
- Add todo to `commands.odin`


- Relates to #184
- closes #187