### PR TITLE
fix: encryption issue

### DIFF
--- a/src/core/engine/security/auth.odin
+++ b/src/core/engine/security/auth.odin
@@ -54,7 +54,7 @@ RUN_USER_SIGNIN :: proc() -> bool {
 		return false
 	}
 
-	secCollection := utils.concat_secure_collection_name(userName)
+	secCollection := utils.concat_secure_collection_name(usernameCapitalized)
 
 	//decrypt the user secure collection
 	decSuccess, _ := DECRYPT_COLLECTION(


### PR DESCRIPTION
When reading the file, the username was not correct, as it needed to be all uppercase as per the secure filename.