### PR TITLE
287 add ollama to ci

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -15,6 +15,10 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Install Ollama
+        id: install-ollama
+        run: brew install ollama
+
       - name: Set up Go-lang
         run: brew install go
 

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -11,6 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install cURL
+        run: |
+          sudo apt install curl
+
+      - name: Install Ollama
+        run: |
+          curl -fsSL https://ollama.com/install.sh | sh
+
       - name: Install Go-lang
         run: |
           sudo apt install golang


### PR DESCRIPTION
This pull request contains the following changes:

1. Update both macOS and Ubuntu CI with:
    - Ollama Install  

2. Added cURL install instruction to Ubuntu CI
